### PR TITLE
fix(Link):  mergeProps  shouldn't override user props

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -19,9 +19,7 @@ type Props<Params extends RouteParams> = {
 } & Exclude<JSX.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
 
 export function Link<Params extends RouteParams>(props: Props<Params>) {
-  props = mergeProps(props, {
-    activeClass: 'active',
-  });
+  props = mergeProps({activeClass: 'active'}, props);
 
   const toIsString = createMemo(() => typeof props.to === 'string');
 


### PR DESCRIPTION
Currently if i will pass `activeClass` prop that will be overwritten by default value - `active`