### PR TITLE
fix types import

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "node": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
+      "default": "./dist/esm/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Now typescript will resolve types for module correctly. Create based on issue #11 